### PR TITLE
feat: adding support for namespaces

### DIFF
--- a/.changeset/silent-avocados-sell.md
+++ b/.changeset/silent-avocados-sell.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/phrasebook': minor
+---
+
+Adding support for namespaces

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Phrasebook
 
-A lightweight translation library for React/Preact projects with a similar interface to `react-i18next`. Currently in production on www.loveholidays.com.
+A lightweight translation library for React/Preact projects with a similar interface to `react-i18next`.
+
+Made with ❤️ by [loveholidays.com](https://www.loveholidays.com)
 
 ## Why phrasebook?
 
@@ -96,6 +98,42 @@ The goal is to provide a lightweight alternative for the most common used featur
 
 - There is no support for [translation backends](https://www.i18next.com/how-to/add-or-load-translations#combined-with-a-backend-plugin), the translation object must be loaded and passed in to the `TranslationProvider`.
 - The translation object format is not fully compatible with the [i18next JSON format](https://www.i18next.com/misc/json-format), the currently supported features are: nested translations, `_plural` suffix, [contexts](https://www.i18next.com/translation-function/context#basic).
+
+## Namespaces
+
+Namespaced translations can be used with `<TranslationProvider />` by passing an object into the `namespaces` prop - where the keys are the names of the namespaces and the values are the translations for the given namespace:
+
+```tsx
+<TranslationProvider
+  locale={locale}
+  namespaces={{
+    homepage: {
+      title: 'Homepage',
+    },
+    checkout: {
+      title: 'Checkout',
+    },
+  }}
+>
+```
+
+The `ns` option controls the namespace when using the `t` function:
+
+```tsx
+const { t } = useTranslation();
+
+const homepageTitle = t('title', { ns: 'homepage' });
+const checkoutTitle = t('title', { ns: 'checkout' });
+```
+
+To avoid repeating the `ns` option when using `t`, the default namespace can be changed when using the `useTranslation` hook:
+
+```tsx
+const { t } = useTranslation('homepage');
+
+const homepageTitle = t('title');
+const checkoutTitle = t('title', { namespace: 'checkout' });
+```
 
 ## i18n ally extension support for VS Code
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ This package exports native [ESM](https://developer.mozilla.org/en-US/docs/Web/J
 
 ## Bundle size comparisons
 
-| Package                  | Bundle size                                                             | Difference                      |
-| ------------------------ | ----------------------------------------------------------------------- | ------------------------------- |
-| react-i18next            | [6.5kb](https://bundlephobia.com/package/react-i18next@11.16.2)         |                                 |
-| @loveholidays/phrasebook | [883b](https://bundlephobia.com/package/@loveholidays/phrasebook@0.0.4) | 736% smaller than react-i18next |
-| @lingui/react            | [2.5kb](https://bundlephobia.com/package/@lingui/react@3.13.2)          | 260% smaller than react-i18next |
+| Package                  | Bundle size                                                       | Difference |
+| ------------------------ | ----------------------------------------------------------------- | ---------- |
+| @loveholidays/phrasebook | [948b](https://bundlephobia.com/package/@loveholidays/phrasebook) | baseline   |
+| @lingui/react            | [1.6kb](https://bundlephobia.com/package/@lingui/react@3.17.2)    | + 68%      |
+| react-i18next            | [7.1kb](https://bundlephobia.com/package/react-i18next@12.2.0)    | + 650%     |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ const homepageTitle = t('title');
 const checkoutTitle = t('title', { namespace: 'checkout' });
 ```
 
+The `Translation` component takes an optional `namespace` prop to achieve the same:
+
+```tsx
+  <Translation
+    translationKey="myKey"
+    namespace="myNamespace"
+    params={ ... }
+    components={ ... }
+  />
+```
+
 ## i18n ally extension support for VS Code
 
 We highly recommend to use the [i18n ally](https://github.com/lokalise/i18n-ally) extension for VS Code users. To make it work with phrasebook you need to add this file to your project:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This package exports native [ESM](https://developer.mozilla.org/en-US/docs/Web/J
 
 ## Bundle size comparisons
 
-| Package                  | Bundle size                                                       | Difference |
+| Package                  | Bundle size (gzip)                                                | Difference |
 | ------------------------ | ----------------------------------------------------------------- | ---------- |
-| @loveholidays/phrasebook | [948b](https://bundlephobia.com/package/@loveholidays/phrasebook) | baseline   |
+| @loveholidays/phrasebook | [956b](https://bundlephobia.com/package/@loveholidays/phrasebook) | baseline   |
 | @lingui/react            | [1.6kb](https://bundlephobia.com/package/@lingui/react@3.17.2)    | + 68%      |
 | react-i18next            | [7.1kb](https://bundlephobia.com/package/react-i18next@12.2.0)    | + 650%     |
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -11,14 +11,11 @@ esbuild
     outdir: 'lib',
     bundle: true,
     sourcemap: true,
-    minify: false,
+    minify: true,
     splitting: true,
     format: 'esm',
     target: ['es2019'],
-    external: [
-      'react',
-      'react-dom',
-    ],
+    external: ['react', 'react-dom'],
   })
   .catch((e) => {
     console.log(e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/parser": "^5.17.0",
         "babel-jest": "^27.5.1",
         "babel-loader": "^8.2.4",
-        "esbuild": "^0.14.29",
+        "esbuild": "^0.17.17",
         "eslint": "^7.32.0",
         "glob": "^7.2.0",
         "jest": "^27.5.1",
@@ -2459,6 +2459,358 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.17.tgz",
+      "integrity": "sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz",
+      "integrity": "sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.17.tgz",
+      "integrity": "sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz",
+      "integrity": "sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz",
+      "integrity": "sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz",
+      "integrity": "sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz",
+      "integrity": "sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz",
+      "integrity": "sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz",
+      "integrity": "sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz",
+      "integrity": "sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz",
+      "integrity": "sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz",
+      "integrity": "sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz",
+      "integrity": "sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz",
+      "integrity": "sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz",
+      "integrity": "sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz",
+      "integrity": "sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz",
+      "integrity": "sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz",
+      "integrity": "sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz",
+      "integrity": "sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz",
+      "integrity": "sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz",
+      "integrity": "sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -5171,9 +5523,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.29.tgz",
-      "integrity": "sha512-SQS8cO8xFEqevYlrHt6exIhK853Me4nZ4aMW6ieysInLa0FMAL+AKs87HYNRtR2YWRcEIqoXAHh+Ytt5/66qpg==",
+      "version": "0.17.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz",
+      "integrity": "sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -5183,58 +5535,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.29",
-        "esbuild-android-arm64": "0.14.29",
-        "esbuild-darwin-64": "0.14.29",
-        "esbuild-darwin-arm64": "0.14.29",
-        "esbuild-freebsd-64": "0.14.29",
-        "esbuild-freebsd-arm64": "0.14.29",
-        "esbuild-linux-32": "0.14.29",
-        "esbuild-linux-64": "0.14.29",
-        "esbuild-linux-arm": "0.14.29",
-        "esbuild-linux-arm64": "0.14.29",
-        "esbuild-linux-mips64le": "0.14.29",
-        "esbuild-linux-ppc64le": "0.14.29",
-        "esbuild-linux-riscv64": "0.14.29",
-        "esbuild-linux-s390x": "0.14.29",
-        "esbuild-netbsd-64": "0.14.29",
-        "esbuild-openbsd-64": "0.14.29",
-        "esbuild-sunos-64": "0.14.29",
-        "esbuild-windows-32": "0.14.29",
-        "esbuild-windows-64": "0.14.29",
-        "esbuild-windows-arm64": "0.14.29"
-      }
-    },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.29.tgz",
-      "integrity": "sha512-+CJaRvfTkzs9t+CjGa0Oa28WoXa7EeLutQhxus+fFcu0MHhsBhlmeWHac3Cc/Sf/xPi1b2ccDFfzGYJCfV0RrA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.29",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.29.tgz",
-      "integrity": "sha512-5Wgz/+zK+8X2ZW7vIbwoZ613Vfr4A8HmIs1XdzRmdC1kG0n5EG5fvKk/jUxhNlrYPx1gSY7XadQ3l4xAManPSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
+        "@esbuild/android-arm": "0.17.17",
+        "@esbuild/android-arm64": "0.17.17",
+        "@esbuild/android-x64": "0.17.17",
+        "@esbuild/darwin-arm64": "0.17.17",
+        "@esbuild/darwin-x64": "0.17.17",
+        "@esbuild/freebsd-arm64": "0.17.17",
+        "@esbuild/freebsd-x64": "0.17.17",
+        "@esbuild/linux-arm": "0.17.17",
+        "@esbuild/linux-arm64": "0.17.17",
+        "@esbuild/linux-ia32": "0.17.17",
+        "@esbuild/linux-loong64": "0.17.17",
+        "@esbuild/linux-mips64el": "0.17.17",
+        "@esbuild/linux-ppc64": "0.17.17",
+        "@esbuild/linux-riscv64": "0.17.17",
+        "@esbuild/linux-s390x": "0.17.17",
+        "@esbuild/linux-x64": "0.17.17",
+        "@esbuild/netbsd-x64": "0.17.17",
+        "@esbuild/openbsd-x64": "0.17.17",
+        "@esbuild/sunos-x64": "0.17.17",
+        "@esbuild/win32-arm64": "0.17.17",
+        "@esbuild/win32-ia32": "0.17.17",
+        "@esbuild/win32-x64": "0.17.17"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@typescript-eslint/parser": "^5.17.0",
     "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.4",
-    "esbuild": "^0.14.29",
+    "esbuild": "^0.17.17",
     "eslint": "^7.32.0",
     "glob": "^7.2.0",
     "jest": "^27.5.1",

--- a/src/TranslationComponent.spec.tsx
+++ b/src/TranslationComponent.spec.tsx
@@ -5,16 +5,16 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Translation } from './TranslationComponent';
 import { TranslationProvider } from './TranslationProvider';
+import namespaces from './testing/testNamespaces.json';
 
 describe('Translation component', () => {
   const locale = 'en-GB';
-  const translations = require('./testing/testTranslations.json');
 
   it('translates the default component', () => {
     const { asFragment } = render(
       <TranslationProvider
         locale={locale}
-        translations={translations}
+        namespaces={namespaces}
       >
         <Translation
           translationKey="translationComponent"
@@ -37,7 +37,7 @@ describe('Translation component', () => {
     const { asFragment } = render(
       <TranslationProvider
         locale={locale}
-        translations={translations}
+        namespaces={namespaces}
       >
         <Translation
           translationKey="oneParamTwoComponents"
@@ -59,7 +59,7 @@ describe('Translation component', () => {
     const { asFragment } = render(
       <TranslationProvider
         locale={locale}
-        translations={translations}
+        namespaces={namespaces}
       >
         <Translation
           translationKey="twoParamsOneComponent"
@@ -81,7 +81,7 @@ describe('Translation component', () => {
     const { asFragment } = render(
       <TranslationProvider
         locale={locale}
-        translations={translations}
+        namespaces={namespaces}
       >
         <Translation
           translationKey="componentWithChildren"

--- a/src/TranslationComponent.spec.tsx
+++ b/src/TranslationComponent.spec.tsx
@@ -33,6 +33,28 @@ describe('Translation component', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('translates using the provided namespace ', () => {
+    const { asFragment } = render(
+      <TranslationProvider
+        locale={locale}
+        namespaces={namespaces}
+      >
+        <Translation
+          translationKey="textWithPlaceholders"
+          namespace="ns1"
+          params={{
+            first: '_',
+          }}
+          components={[
+            <strong key={1}>@</strong>,
+          ]}
+        />
+      </TranslationProvider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('translates with one param and two components', () => {
     const { asFragment } = render(
       <TranslationProvider

--- a/src/TranslationComponent.tsx
+++ b/src/TranslationComponent.tsx
@@ -38,16 +38,18 @@ const resolveParts = (parts: string[], components: TranslationComponent[]) => pa
 
 interface TranslationProps {
   translationKey: string;
+  namespace?: string;
   params?: Record<string, string | number | undefined>;
   components?: TranslationComponent[];
 }
 
 export const Translation: React.FC<TranslationProps> = ({
   translationKey,
+  namespace,
   params = {},
   components = [],
 }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(namespace);
   const translation = t(translationKey, params);
   const parts = translation.split(regExp.extractComponents);
   const resolvedParts = resolveParts(parts, components);

--- a/src/TranslationProvider.spec.tsx
+++ b/src/TranslationProvider.spec.tsx
@@ -4,52 +4,90 @@ import { render } from '@testing-library/react';
 import { TranslationProvider, useTranslation } from './TranslationProvider';
 import { TranslationArguments } from './types';
 
+import namespaces from './testing/testNamespaces.json';
+
+interface TestComponentProps {
+  name: string;
+  namespace?: string;
+  args?: TranslationArguments;
+}
+
+const TestComponent: React.FC<TestComponentProps> = ({
+  name,
+  namespace,
+  args,
+}) => {
+  const { t } = useTranslation(namespace);
+
+  return (
+    <span>{t(name, args)}</span>
+  );
+};
+
 describe('TranslationProvider', () => {
   const locale = 'en-GB';
-  const translations = {
-    search: {
-      label: 'Search',
-    },
-    reviews: '{{count}} review',
-    reviews_plural: '{{count}} reviews',
-    boardBasis: {
-      code: 'Board Basis',
-      code_AI: 'All Inclusive',
-    },
-  };
 
-  it('translates using useTranslation hook', () => {
-    const Test: React.FC<{ name: string; args?: TranslationArguments }> = ({ name, args }) => {
-      const { t } = useTranslation();
-
-      return (
-        <span>{t(name, args)}</span>
-      );
-    };
-
+  it('exposes the translation function via useTranslation hook', () => {
     const { asFragment } = render(
       <TranslationProvider
         locale={locale}
-        translations={translations}
+        namespaces={namespaces}
       >
-        <Test
+        <TestComponent
           name="search.label"
         />
-        <Test
+        <TestComponent
           name="reviews"
           args={{ count: 1 }}
         />
-        <Test
+        <TestComponent
           name="reviews"
           args={{ count: 4 }}
         />
-        <Test
+        <TestComponent
           name="boardBasis.code"
         />
-        <Test
+        <TestComponent
           name="boardBasis.code"
           args={{ context: 'AI' }}
         />
+        <TestComponent
+          name="title"
+          namespace="ns1"
+        />
+        <TestComponent
+          name="title"
+          args={{ ns: 'ns2' }}
+        />
+      </TranslationProvider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('merges namespaces when nesting providers', () => {
+    const { asFragment } = render(
+      <TranslationProvider
+        locale={locale}
+        namespaces={{
+          ns1: namespaces.ns1,
+        }}
+      >
+        <TranslationProvider
+          locale={locale}
+          namespaces={{
+            ns2: namespaces.ns2,
+          }}
+        >
+          <TestComponent
+            name="title"
+            namespace="ns1"
+          />
+          <TestComponent
+            name="title"
+            args={{ ns: 'ns2' }}
+          />
+        </TranslationProvider>
       </TranslationProvider>,
     );
 

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import { DEFAULT_NAMESPACE } from './constants';
 
 import { processTranslation } from './processTranslation';
@@ -39,7 +39,7 @@ const mergeNamespaces = (
   }),
 });
 
-interface UseTranslationReturnValue {
+export interface UseTranslationReturnValue {
   t: TFunction;
 }
 
@@ -59,15 +59,16 @@ export const TranslationProvider: React.FC<TranslationProviderProps> = ({
   children,
 }) => {
   const { namespaces: parentNamespaces } = useContext(TranslationContext);
-  const [ mergedNamespaces ] = useState(
+  const mergedNamespaces = useMemo(
     () => mergeNamespaces(parentNamespaces, namespaces, translations),
+    [ parentNamespaces, namespaces, translations ],
   );
 
   return (
     <TranslationContext.Provider
       value={{
         locale,
-        namespaces: mergeNamespaces(parentNamespaces, namespaces, translations),
+        namespaces: mergedNamespaces,
         t: (key, args) => processTranslation({
           locale,
           namespaces: mergedNamespaces,

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -1,41 +1,83 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState } from 'react';
+import { DEFAULT_NAMESPACE } from './constants';
 
 import { processTranslation } from './processTranslation';
-import { Locale, TFunction, TranslationData } from './types';
+import type {
+  Namespaces, Locale, TFunction, TranslationData,
+} from './types';
 
 export interface TranslationContextValue {
   locale: Locale;
+  namespaces: Namespaces;
   t: TFunction;
 }
 
 export const TranslationContext = createContext<TranslationContextValue>({
   locale: '',
+  namespaces: {},
   t: () => '',
 });
 
 interface TranslationProviderProps {
   locale: Locale;
-  translations: TranslationData;
+  namespaces?: Namespaces;
+  translations?: TranslationData;
 }
+
+// @TODO:
+// - option for deep merge?
+// - option for providing a custom `mergeNamespaces` function?
+const mergeNamespaces = (
+  parentNamespaces: Namespaces = {},
+  namespaces: Namespaces = {},
+  translations?: TranslationData,
+): Namespaces => ({
+  ...parentNamespaces,
+  ...namespaces,
+  ...(translations && {
+    [DEFAULT_NAMESPACE]: translations,
+  }),
+});
+
+interface UseTranslationReturnValue {
+  t: TFunction;
+}
+
+export const useTranslation = (namespace?: string) => ({
+  t: namespace
+    ? (key, args) => useContext(TranslationContext).t(key, {
+      ns: namespace,
+      ...args,
+    })
+    : useContext(TranslationContext).t,
+}) as UseTranslationReturnValue;
 
 export const TranslationProvider: React.FC<TranslationProviderProps> = ({
   locale,
+  namespaces,
   translations,
   children,
-}) => (
-  <TranslationContext.Provider
-    value={{
-      locale,
-      t: (key, args) => processTranslation({
-        locale,
-        translations,
-        key,
-        args,
-      }),
-    }}
-  >
-    {children}
-  </TranslationContext.Provider>
-);
+}) => {
+  const { namespaces: parentNamespaces } = useContext(TranslationContext);
+  const [ mergedNamespaces ] = useState(
+    () => mergeNamespaces(parentNamespaces, namespaces, translations),
+  );
 
-export const useTranslation = () => useContext(TranslationContext);
+  return (
+    <TranslationContext.Provider
+      value={{
+        locale,
+        namespaces: mergeNamespaces(parentNamespaces, namespaces, translations),
+        t: (key, args) => processTranslation({
+          locale,
+          namespaces: mergedNamespaces,
+          key,
+          args,
+        }),
+      }}
+    >
+      {children}
+    </TranslationContext.Provider>
+  );
+};
+

--- a/src/__snapshots__/TranslationComponent.spec.tsx.snap
+++ b/src/__snapshots__/TranslationComponent.spec.tsx.snap
@@ -14,6 +14,16 @@ exports[`Translation component translates the default component 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Translation component translates using the provided namespace  1`] = `
+<DocumentFragment>
+  a _ b 
+  <strong>
+    @
+  </strong>
+   c
+</DocumentFragment>
+`;
+
 exports[`Translation component translates when the components have children 1`] = `
 <DocumentFragment>
   this makes it possible to 

--- a/src/__snapshots__/TranslationProvider.spec.tsx.snap
+++ b/src/__snapshots__/TranslationProvider.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TranslationProvider translates using useTranslation hook 1`] = `
+exports[`TranslationProvider exposes the translation function via useTranslation hook 1`] = `
 <DocumentFragment>
   <span>
     Search
@@ -16,6 +16,23 @@ exports[`TranslationProvider translates using useTranslation hook 1`] = `
   </span>
   <span>
     All Inclusive
+  </span>
+  <span>
+    title from namespace 1
+  </span>
+  <span>
+    title from namespace 2
+  </span>
+</DocumentFragment>
+`;
+
+exports[`TranslationProvider merges namespaces when nesting providers 1`] = `
+<DocumentFragment>
+  <span>
+    title from namespace 1
+  </span>
+  <span>
+    title from namespace 2
   </span>
 </DocumentFragment>
 `;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_NAMESPACE = '';

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -1,20 +1,8 @@
 import { processTranslation } from './processTranslation';
+import namespaces from './testing/testNamespaces.json';
 
 describe('processTranslation', () => {
   const locale = 'en-GB';
-  const translations = {
-    search: {
-      label: 'Search',
-    },
-    reviews: '{{count}} review',
-    reviews_plural: '{{count}} reviews',
-    boardBasis: {
-      code: 'Board Basis',
-      code_AI: 'All Inclusive',
-      code_BB: 'Breakfast Included',
-    },
-    empty: '',
-  };
 
   it.each([
     [ 'search.label', {}, 'Search' ],
@@ -26,11 +14,12 @@ describe('processTranslation', () => {
     [ 'boardBasis.code', {}, 'Board Basis' ],
     [ 'boardBasis.code', { context: 'AI' }, 'All Inclusive' ],
     [ 'empty', {}, '' ],
+    [ 'title', { ns: 'ns1' }, 'title from namespace 1' ],
   ])('%s %p => %s', (key, args, expected) => {
     expect(
       processTranslation({
         locale,
-        translations,
+        namespaces,
         key,
         args,
       }),
@@ -41,7 +30,7 @@ describe('processTranslation', () => {
     expect(
       () => processTranslation({
         locale,
-        translations,
+        namespaces,
         key: 'missing.translation.key',
       }),
     ).toThrow('Missing translation: "missing.translation.key"');
@@ -49,7 +38,7 @@ describe('processTranslation', () => {
     expect(
       () => processTranslation({
         locale,
-        translations,
+        namespaces,
         key: 'boardBasis',
         args: { context: 'foo' },
       }),

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -1,5 +1,6 @@
+import { DEFAULT_NAMESPACE } from './constants';
 import {
-  Locale, TranslationArguments, TranslationArgumentValue, TranslationData,
+  Locale, Namespaces, TranslationArguments, TranslationArgumentValue, TranslationData,
 } from './types';
 
 const formatArgument = (
@@ -19,22 +20,24 @@ const formatArgument = (
 
 interface ProcessTranslationParams {
   locale: Locale;
-  translations: TranslationData;
+  namespaces: Namespaces;
   key: string;
   args?: TranslationArguments;
 }
 
 export const processTranslation = ({
   locale,
-  translations,
+  namespaces,
   key,
   args = {},
 }: ProcessTranslationParams) => {
+  const namespaceName = args.ns ?? DEFAULT_NAMESPACE;
+
   const parts = key.split('.');
   const lastPart = parts[parts.length - 1];
   const root = parts.slice(0, -1).reduce(
     (root, part) => root?.[part] as TranslationData,
-    translations,
+    namespaces[namespaceName],
   );
 
   if (typeof root !== 'object') {

--- a/src/testing/testNamespaces.json
+++ b/src/testing/testNamespaces.json
@@ -1,0 +1,24 @@
+{
+  "ns1": {
+    "title": "title from namespace 1"
+  },
+  "ns2": {
+    "title": "title from namespace 2"
+  },
+  "": {
+    "search": {
+      "label": "Search"
+    },
+    "reviews": "{{count}} review",
+    "reviews_plural": "{{count}} reviews",
+    "boardBasis": {
+      "code": "Board Basis",
+      "code_AI": "All Inclusive"
+    },
+    "empty": "",
+    "translationComponent": "param first {{ first }} param second {{ second }} component one <1> component 2 <2> something at the end",
+    "oneParamTwoComponents": "param first {{ first }} component one <1> component 2 <2> something at the end",
+    "twoParamsOneComponent": "param first {{ first }} param second {{ second }} component one <1> something at the end",
+    "componentWithChildren": "this makes it possible to <1>make some parts</1> of the <2>text</2> appear as links"
+  }
+}

--- a/src/testing/testNamespaces.json
+++ b/src/testing/testNamespaces.json
@@ -1,6 +1,7 @@
 {
   "ns1": {
-    "title": "title from namespace 1"
+    "title": "title from namespace 1",
+    "textWithPlaceholders": "a {{ first }} b <1> c"
   },
   "ns2": {
     "title": "title from namespace 2"

--- a/src/testing/testTranslations.json
+++ b/src/testing/testTranslations.json
@@ -1,6 +1,0 @@
-{
-  "translationComponent": "param first {{ first }} param second {{ second }} component one <1> component 2 <2> something at the end",
-  "oneParamTwoComponents": "param first {{ first }} component one <1> component 2 <2> something at the end",
-  "twoParamsOneComponent": "param first {{ first }} param second {{ second }} component one <1> something at the end",
-  "componentWithChildren": "this makes it possible to <1>make some parts</1> of the <2>text</2> appear as links"
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ export interface TranslationData {
   [key: string]: string | TranslationData;
 }
 
+export type Namespaces = Record<string, TranslationData>;
+
 export type TranslationArgumentValue = string | number | undefined;
 
 export type TranslationArguments = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "jsx": "react",
     "module": "commonjs",
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "strict": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
# Description

i18next has [multiple ways](https://www.i18next.com/principles/namespaces#sample) of defining the namespace when using the `t` function.
We decided to go with the `t('key', { ns: 'namespace-name' })` syntax only - we can add support for the other ones as well if needed.

Bumping this as a minor, as the previous `translations` prop of `TranslationProvider` still works as before, and can be used in combination with the new `namespaces` prop.