### PR TITLE
Adding onError handler

### DIFF
--- a/.changeset/bright-bulldogs-dress.md
+++ b/.changeset/bright-bulldogs-dress.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/phrasebook': minor
+---
+
+Adding onError callback for arguments substitution errors

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ const App = () => (
     translations={translations}
     onError={(errorType, data) => {
       const { key, argumentName, value } = data;
-      // this callback could be used to track the error
     }}
   >
     // ...

--- a/README.md
+++ b/README.md
@@ -42,11 +42,8 @@ const App = () => (
   <TranslationProvider
     locale="en-gb"
     translations={translations}
-    onError={(errorMessage, data: {
-      key,
-      argumentName,
-      value
-    }) => {
+    onError={(errorMessage, data) => {
+      const { key, argumentName, value } = data;
       // this callback could be used to handle or to track the error
     }}
   >

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const App = () => (
     translations={translations}
     onError={(errorType, data) => {
       const { key, argumentName, value } = data;
-      // this callback could be used to handle or to track the error
+      // this callback could be used to track the error
     }}
   >
     // ...

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const App = () => (
   <TranslationProvider
     locale="en-gb"
     translations={translations}
-    onError={(errorMessage, data) => {
+    onError={(errorType, data) => {
       const { key, argumentName, value } = data;
       // this callback could be used to handle or to track the error
     }}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ const App = () => (
   <TranslationProvider
     locale="en-gb"
     translations={translations}
+    onError={(errorMessage, data: {
+      key,
+      argumentName,
+      value
+    }) => {
+      // this callback could be used to handle or to track the error
+    }}
   >
     // ...
   </TranslationProvider>

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -22,7 +22,7 @@ interface TranslationProviderProps {
   locale: Locale;
   namespaces?: Namespaces;
   translations?: TranslationData;
-  onError?: (error: Error | string) => void;
+  onError?: <T extends any>(error: T | Error | string, data: any) => void;
 }
 
 // @TODO:

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -18,22 +18,20 @@ export const TranslationContext = createContext<TranslationContextValue>({
   t: () => '',
 });
 
-export type ErrorType = 'REPLACE_ARGUMENT_NOT_FOUND';
-
 export interface ReplaceArgumentErrorParams {
   key: string;
   argumentName: string;
   value: TranslationArgumentValue;
 }
 
+export type OnErrorType =
+  & ((errorType: 'REPLACE_ARGUMENT_NOT_FOUND', params: ReplaceArgumentErrorParams) => void);
+
 interface TranslationProviderProps {
   locale: Locale;
   namespaces?: Namespaces;
   translations?: TranslationData;
-  onError?: (
-    errorType: ErrorType,
-    params: ReplaceArgumentErrorParams,
-  ) => void;
+  onError?: OnErrorType;
 }
 
 // @TODO:

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -18,17 +18,21 @@ export const TranslationContext = createContext<TranslationContextValue>({
   t: () => '',
 });
 
+export type ErrorType = 'REPLACE_ARGUMENT_NOT_FOUND';
+
+export type ReplaceArgumentErrorParams = {
+  key: string;
+  argumentName: string;
+  value: TranslationArgumentValue;
+};
+
 interface TranslationProviderProps {
   locale: Locale;
   namespaces?: Namespaces;
   translations?: TranslationData;
   onError?: (
-    error: string,
-    data: {
-      key: string;
-      argumentName: string;
-      value: TranslationArgumentValue;
-    }
+    errorType: ErrorType,
+    params: ReplaceArgumentErrorParams,
   ) => void;
 }
 

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -24,7 +24,7 @@ export interface ReplaceArgumentErrorParams {
   key: string;
   argumentName: string;
   value: TranslationArgumentValue;
-};
+}
 
 interface TranslationProviderProps {
   locale: Locale;

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -23,7 +23,7 @@ interface TranslationProviderProps {
   namespaces?: Namespaces;
   translations?: TranslationData;
   onError?: (
-    error: Error | string,
+    error: string,
     data: {
       key: string;
       argumentName: string;

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -22,6 +22,7 @@ interface TranslationProviderProps {
   locale: Locale;
   namespaces?: Namespaces;
   translations?: TranslationData;
+  onError?: (error: Error | string) => void;
 }
 
 // @TODO:
@@ -56,6 +57,7 @@ export const TranslationProvider: React.FC<TranslationProviderProps> = ({
   locale,
   namespaces,
   translations,
+  onError,
   children,
 }) => {
   const { namespaces: parentNamespaces } = useContext(TranslationContext);
@@ -74,6 +76,7 @@ export const TranslationProvider: React.FC<TranslationProviderProps> = ({
           namespaces: mergedNamespaces,
           key,
           args,
+          onError,
         }),
       }}
     >

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -64,6 +64,15 @@ export const useTranslation = (namespace?: string) => ({
     : useContext(TranslationContext).t,
 }) as UseTranslationReturnValue;
 
+/**
+ * TranslationProvider
+ * Provider used to create the localisation context.
+ * @param {object} props
+ * @param {string} props.locale String is used for locale specific formatting.
+ * @param {object} props.namespaces Namespaced translations where the keys are the names of the namespaces and the values are the translations for the given namespace.
+ * @param {object} props.translations Translation for default locale.
+ * @param {function} props.onError Callback could be used to track the error during translation processing.
+ * */
 export const TranslationProvider: React.FC<TranslationProviderProps> = ({
   locale,
   namespaces,

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -24,14 +24,14 @@ export interface ReplaceArgumentErrorParams {
   value: TranslationArgumentValue;
 }
 
-export type OnErrorType =
+export type OnErrorCallback =
   & ((errorType: 'REPLACE_ARGUMENT_NOT_FOUND', params: ReplaceArgumentErrorParams) => void);
 
 interface TranslationProviderProps {
   locale: Locale;
   namespaces?: Namespaces;
   translations?: TranslationData;
-  onError?: OnErrorType;
+  onError?: OnErrorCallback;
 }
 
 // @TODO:

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_NAMESPACE } from './constants';
 
 import { processTranslation } from './processTranslation';
 import type {
-  Namespaces, Locale, TFunction, TranslationData,
+  Namespaces, Locale, TFunction, TranslationData, TranslationArgumentValue,
 } from './types';
 
 export interface TranslationContextValue {
@@ -22,7 +22,14 @@ interface TranslationProviderProps {
   locale: Locale;
   namespaces?: Namespaces;
   translations?: TranslationData;
-  onError?: <T extends any>(error: T | Error | string, data: any) => void;
+  onError?: (
+    error: Error | string,
+    data: {
+      key: string;
+      argumentName: string;
+      value: TranslationArgumentValue;
+    }
+  ) => void;
 }
 
 // @TODO:

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -20,7 +20,7 @@ export const TranslationContext = createContext<TranslationContextValue>({
 
 export type ErrorType = 'REPLACE_ARGUMENT_NOT_FOUND';
 
-export type ReplaceArgumentErrorParams = {
+export interface ReplaceArgumentErrorParams {
   key: string;
   argumentName: string;
   value: TranslationArgumentValue;

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -48,10 +48,6 @@ describe('processTranslation', () => {
   describe('when calling with wrong param', () => {
     const onError = jest.fn();
 
-    beforeEach(() => {
-      console.error = jest.fn();
-    });
-
     it('Should log the error', () => {
       expect(processTranslation({
         locale,
@@ -61,7 +57,6 @@ describe('processTranslation', () => {
         onError,
       })).toBe('text with parameter: {{wrongParam}}');
 
-      expect(console.error).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid');
       expect(onError).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid');
     });
   });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -4,44 +4,44 @@ import namespaces from './testing/testNamespaces.json';
 describe('processTranslation', () => {
   const locale = 'en-GB';
 
-  it.each([
-    [ 'search.label', {}, 'Search' ],
-    [ 'reviews', { count: -10 }, '-10 reviews' ],
-    [ 'reviews', { count: 0 }, '0 reviews' ],
-    [ 'reviews', { count: 1 }, '1 review' ],
-    [ 'reviews', { count: -1 }, '-1 review' ],
-    [ 'reviews', { count: 123 }, '123 reviews' ],
-    [ 'boardBasis.code', {}, 'Board Basis' ],
-    [ 'boardBasis.code', { context: 'AI' }, 'All Inclusive' ],
-    [ 'empty', {}, '' ],
-    [ 'title', { ns: 'ns1' }, 'title from namespace 1' ],
-  ])('%s %p => %s', (key, args, expected) => {
-    expect(
-      processTranslation({
-        locale,
-        namespaces,
-        key,
-        args,
-      }),
-    ).toBe(expected);
+  describe('Should return expected translated value', () => {
+    it.each([
+      [ 'search.label', {}, 'Search' ],
+      [ 'reviews', { count: -10 }, '-10 reviews' ],
+      [ 'reviews', { count: 0 }, '0 reviews' ],
+      [ 'reviews', { count: 1 }, '1 review' ],
+      [ 'reviews', { count: -1 }, '-1 review' ],
+      [ 'reviews', { count: 123 }, '123 reviews' ],
+      [ 'boardBasis.code', {}, 'Board Basis' ],
+      [ 'boardBasis.code', { context: 'AI' }, 'All Inclusive' ],
+      [ 'empty', {}, '' ],
+      [ 'title', { ns: 'ns1' }, 'title from namespace 1' ],
+    ])('%s %p => %s', (key, args, expected) => {
+      expect(
+        processTranslation({
+          locale,
+          namespaces,
+          key,
+          args,
+        }),
+      ).toBe(expected);
+    });
   });
 
-  it('throws error when translation was not found', () => {
-    expect(
-      () => processTranslation({
-        locale,
-        namespaces,
-        key: 'missing.translation.key',
-      }),
-    ).toThrow('Missing translation: "missing.translation.key"');
-
-    expect(
-      () => processTranslation({
-        locale,
-        namespaces,
-        key: 'boardBasis',
-        args: { context: 'foo' },
-      }),
-    ).toThrow('Missing translation: "boardBasis" with suffix: "foo"');
+  describe('Should throw expected error', () => {
+    it.each([
+      [ 'missing.translation.key', {}, 'Missing translation: "missing.translation.key"' ],
+      [ 'boardBasis', { context: 'foo' }, 'Missing translation: "boardBasis" with suffix: "foo"' ],
+      [ 'reviews', { missingArgument: 'foo' }, 'Argument: "missingArgument" with value: "foo" is not valid' ],
+    ])('Should throw exception %s %p => %s', (key, args, expected) => {
+      expect(
+        () => processTranslation({
+          locale,
+          namespaces,
+          key,
+          args,
+        }),
+      ).toThrow(expected);
+    });
   });
 });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -57,7 +57,11 @@ describe('processTranslation', () => {
         onError,
       })).toBe('text with parameter: {{wrongParam}}');
 
-      expect(onError).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid');
+      expect(onError).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid', {
+        key: 'stringWithParam',
+        argName: 'param',
+        value: 'foo',
+      });
     });
   });
 });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -46,6 +46,8 @@ describe('processTranslation', () => {
   });
 
   describe('when calling with wrong param', () => {
+    const onError = jest.fn();
+
     beforeEach(() => {
       console.error = jest.fn();
     });
@@ -56,9 +58,11 @@ describe('processTranslation', () => {
         namespaces,
         key: 'stringWithParam',
         args: { ns: 'ns1', param: 'foo' },
+        onError,
       })).toBe('text with parameter: {{wrongParam}}');
 
       expect(console.error).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid');
+      expect(onError).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid');
     });
   });
 });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -57,7 +57,7 @@ describe('processTranslation', () => {
         onError,
       })).toBe('text with parameter: {{wrongParam}}');
 
-      expect(onError).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid', {
+      expect(onError).toHaveBeenCalledWith('REPLACE_ARGUMENT_NOT_FOUND', {
         key: 'stringWithParam',
         argumentName: 'param',
         value: 'foo',

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -33,7 +33,6 @@ describe('processTranslation', () => {
     it.each([
       [ 'missing.translation.key', {}, 'Missing translation: "missing.translation.key"' ],
       [ 'boardBasis', { context: 'foo' }, 'Missing translation: "boardBasis" with suffix: "foo"' ],
-      [ 'stringWithParam', { ns: 'ns1', param: 'foo' }, 'Argument: "param" with value: "foo" is not valid' ],
     ])('Should throw exception %s %p => %s', (key, args, expected) => {
       expect(
         () => processTranslation({
@@ -43,6 +42,23 @@ describe('processTranslation', () => {
           args,
         }),
       ).toThrow(expected);
+    });
+  });
+
+  describe('when calling with wrong param', () => {
+    beforeEach(() => {
+      console.error = jest.fn();
+    });
+
+    it('Should log the error', () => {
+      expect(processTranslation({
+        locale,
+        namespaces,
+        key: 'stringWithParam',
+        args: { ns: 'ns1', param: 'foo' },
+      })).toBe('text with parameter: {{wrongParam}}');
+
+      expect(console.error).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid');
     });
   });
 });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -59,7 +59,7 @@ describe('processTranslation', () => {
 
       expect(onError).toHaveBeenCalledWith('Argument: "param" with value: "foo" is not valid', {
         key: 'stringWithParam',
-        argName: 'param',
+        argumentName: 'param',
         value: 'foo',
       });
     });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -16,6 +16,7 @@ describe('processTranslation', () => {
       [ 'boardBasis.code', { context: 'AI' }, 'All Inclusive' ],
       [ 'empty', {}, '' ],
       [ 'title', { ns: 'ns1' }, 'title from namespace 1' ],
+      [ 'stringWithParam', { param: 'foo' }, 'text with parameter: foo' ],
     ])('%s %p => %s', (key, args, expected) => {
       expect(
         processTranslation({
@@ -32,7 +33,7 @@ describe('processTranslation', () => {
     it.each([
       [ 'missing.translation.key', {}, 'Missing translation: "missing.translation.key"' ],
       [ 'boardBasis', { context: 'foo' }, 'Missing translation: "boardBasis" with suffix: "foo"' ],
-      [ 'reviews', { missingArgument: 'foo' }, 'Argument: "missingArgument" with value: "foo" is not valid' ],
+      [ 'stringWithParam', { ns: 'ns1', param: 'foo' }, 'Argument: "param" with value: "foo" is not valid' ],
     ])('Should throw exception %s %p => %s', (key, args, expected) => {
       expect(
         () => processTranslation({

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -73,10 +73,8 @@ export const processTranslation = ({
     (v, [ name, value ]) => {
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
 
-      if (!regexp.test(v)) {
-        const errorMessage = `Argument: "${name}" with value: "${value}" is not valid`;
-        console.error(errorMessage);
-        onError?.(errorMessage);
+      if (onError && !regexp.test(v)) {
+        onError(`Argument: "${name}" with value: "${value}" is not valid`);
       }
 
       const localizedValue = String(formatArgument(locale, value));

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -22,6 +22,7 @@ interface ProcessTranslationParams {
   locale: Locale;
   namespaces: Namespaces;
   key: string;
+  onError?: (error: Error | string) => void;
   args?: TranslationArguments;
 }
 
@@ -29,6 +30,7 @@ export const processTranslation = ({
   locale,
   namespaces,
   key,
+  onError,
   args = {},
 }: ProcessTranslationParams) => {
   const namespaceName = args.ns ?? DEFAULT_NAMESPACE;
@@ -73,6 +75,7 @@ export const processTranslation = ({
 
       if (!regexp.test(v)) {
         console.error(`Argument: "${name}" with value: "${value}" is not valid`);
+        onError?.(`Argument: "${name}" with value: "${value}" is not valid`);
       }
 
       const localizedValue = String(formatArgument(locale, value));

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -22,7 +22,14 @@ interface ProcessTranslationParams {
   locale: Locale;
   namespaces: Namespaces;
   key: string;
-  onError?: <T extends any>(error: T | Error | string, data: any) => void;
+  onError?: (
+    error: Error | string,
+    data: {
+      key: string;
+      argumentName: string;
+      value: TranslationArgumentValue;
+    }
+  ) => void;
   args?: TranslationArguments;
 }
 
@@ -76,7 +83,7 @@ export const processTranslation = ({
       if (onError && !regexp.test(v)) {
         onError(
           `Argument: "${name}" with value: "${value}" is not valid`,
-          { key, argName: name, value },
+          { key, argumentName: name, value },
         );
       }
 

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -2,6 +2,7 @@ import { DEFAULT_NAMESPACE } from './constants';
 import {
   Locale, Namespaces, TranslationArguments, TranslationArgumentValue, TranslationData,
 } from './types';
+import type { ErrorType, ReplaceArgumentErrorParams } from './TranslationProvider';
 
 const formatArgument = (
   locale: Locale,
@@ -23,12 +24,8 @@ interface ProcessTranslationParams {
   namespaces: Namespaces;
   key: string;
   onError?: (
-    error: string,
-    data: {
-      key: string;
-      argumentName: string;
-      value: TranslationArgumentValue;
-    }
+    errorType: ErrorType,
+    params: ReplaceArgumentErrorParams,
   ) => void;
   args?: TranslationArguments;
 }
@@ -82,7 +79,7 @@ export const processTranslation = ({
 
       if (onError && !regexp.test(v)) {
         onError(
-          `Argument: "${name}" with value: "${value}" is not valid`,
+          'REPLACE_ARGUMENT_NOT_FOUND',
           { key, argumentName: name, value },
         );
       }

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -22,7 +22,7 @@ interface ProcessTranslationParams {
   locale: Locale;
   namespaces: Namespaces;
   key: string;
-  onError?: (error: Error | string) => void;
+  onError?: <T extends any>(error: T | Error | string, data: any) => void;
   args?: TranslationArguments;
 }
 
@@ -74,7 +74,10 @@ export const processTranslation = ({
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
 
       if (onError && !regexp.test(v)) {
-        onError(`Argument: "${name}" with value: "${value}" is not valid`);
+        onError(
+          `Argument: "${name}" with value: "${value}" is not valid`,
+          { key, argName: name, value },
+        );
       }
 
       const localizedValue = String(formatArgument(locale, value));

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -72,7 +72,7 @@ export const processTranslation = ({
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
 
       if (!regexp.test(v)) {
-        throw new Error(`Argument: "${name}" with value: "${value}" is not valid`);
+        console.error(`Argument: "${name}" with value: "${value}" is not valid`);
       }
 
       const localizedValue = String(formatArgument(locale, value));

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -74,8 +74,9 @@ export const processTranslation = ({
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
 
       if (!regexp.test(v)) {
-        console.error(`Argument: "${name}" with value: "${value}" is not valid`);
-        onError?.(`Argument: "${name}" with value: "${value}" is not valid`);
+        const errorMessage = `Argument: "${name}" with value: "${value}" is not valid`;
+        console.error(errorMessage);
+        onError?.(errorMessage);
       }
 
       const localizedValue = String(formatArgument(locale, value));

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -62,10 +62,18 @@ export const processTranslation = ({
 
   // Replace placeholders like `{{count}}` with values from `args`
   const processed = Object.entries(args).reduce(
-    (v, [ name, value ]) => v.replace(
-      new RegExp(`{{\\s*${name}\\s*}}`, 'g'),
-      String(formatArgument(locale, value)),
-    ),
+    (v, [ name, value ]) => {
+      const localizedValue = String(formatArgument(locale, value))
+
+      if (!localizedValue) {
+        throw new Error(`Missing translation for argument: "${name}" with value: "${value}"`);
+      }
+
+      return v.replace(
+        new RegExp(`{{\\s*${name}\\s*}}`, 'g'),
+        localizedValue,
+      )
+    },
     translation as string,
   );
 

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -23,7 +23,7 @@ interface ProcessTranslationParams {
   namespaces: Namespaces;
   key: string;
   onError?: (
-    error: Error | string,
+    error: string,
     data: {
       key: string;
       argumentName: string;

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_NAMESPACE } from './constants';
 import {
   Locale, Namespaces, TranslationArguments, TranslationArgumentValue, TranslationData,
 } from './types';
-import type { ErrorType, ReplaceArgumentErrorParams } from './TranslationProvider';
+import type { OnErrorType } from './TranslationProvider';
 
 const formatArgument = (
   locale: Locale,
@@ -23,10 +23,7 @@ interface ProcessTranslationParams {
   locale: Locale;
   namespaces: Namespaces;
   key: string;
-  onError?: (
-    errorType: ErrorType,
-    params: ReplaceArgumentErrorParams,
-  ) => void;
+  onError?: OnErrorType;
   args?: TranslationArguments;
 }
 

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -60,22 +60,25 @@ export const processTranslation = ({
     throw new Error(`Missing translation: "${key}" with suffix: "${suffix}"`);
   }
 
-  // Replace placeholders like `{{count}}` with values from `args`
-  const processed = Object.entries(args).reduce(
-    (v, [ name, value ]) => {
-      const localizedValue = String(formatArgument(locale, value))
+  const {
+    context,
+    ns,
+    ...replaceableArgs
+  } = args;
 
-      if (!localizedValue) {
-        throw new Error(`Missing translation for argument: "${name}" with value: "${value}"`);
+  // Replace placeholders like `{{count}}` with values from `args`
+  return Object.entries(replaceableArgs).reduce(
+    (v, [ name, value ]) => {
+      const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
+
+      if (!regexp.test(v)) {
+        throw new Error(`Argument: "${name}" with value: "${value}" is not valid`);
       }
 
-      return v.replace(
-        new RegExp(`{{\\s*${name}\\s*}}`, 'g'),
-        localizedValue,
-      )
+      const localizedValue = String(formatArgument(locale, value));
+
+      return v.replace(regexp, localizedValue);
     },
     translation as string,
   );
-
-  return processed;
 };

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_NAMESPACE } from './constants';
 import {
   Locale, Namespaces, TranslationArguments, TranslationArgumentValue, TranslationData,
 } from './types';
-import type { OnErrorType } from './TranslationProvider';
+import type { OnErrorCallback } from './TranslationProvider';
 
 const formatArgument = (
   locale: Locale,
@@ -23,7 +23,7 @@ interface ProcessTranslationParams {
   locale: Locale;
   namespaces: Namespaces;
   key: string;
-  onError?: OnErrorType;
+  onError?: OnErrorCallback;
   args?: TranslationArguments;
 }
 

--- a/src/testing/testNamespaces.json
+++ b/src/testing/testNamespaces.json
@@ -1,7 +1,8 @@
 {
   "ns1": {
     "title": "title from namespace 1",
-    "textWithPlaceholders": "a {{ first }} b <1> c"
+    "textWithPlaceholders": "a {{ first }} b <1> c",
+    "stringWithParam": "text with parameter: {{wrongParam}}"
   },
   "ns2": {
     "title": "title from namespace 2"
@@ -20,6 +21,7 @@
     "translationComponent": "param first {{ first }} param second {{ second }} component one <1> component 2 <2> something at the end",
     "oneParamTwoComponents": "param first {{ first }} component one <1> component 2 <2> something at the end",
     "twoParamsOneComponent": "param first {{ first }} param second {{ second }} component one <1> something at the end",
-    "componentWithChildren": "this makes it possible to <1>make some parts</1> of the <2>text</2> appear as links"
+    "componentWithChildren": "this makes it possible to <1>make some parts</1> of the <2>text</2> appear as links",
+    "stringWithParam": "text with parameter: {{param}}"
   }
 }


### PR DESCRIPTION
<!-- Have you followed the guidelines in our [Contributing](../CONTRIBUTING.md) document? -->

# Description

Prehistory:
Faced with the situation when some locales have different parameters and this was found only on production. Since for development, we are using mostly the main locale, the errors for other locales could be missed.

And on production, the arguments substitution just falls back without throwing any error.

Such typo for projects with many locales could be hard to find other than manual testing or customer feedback.

Fixes # (issue)

Adding `onError` handler to let consumers the ability to track and log the errors when the argument is wrong.

...updating documentation
