### PR TITLE
Fixing the bug during the error handling.

### DIFF
--- a/.changeset/lovely-jokes-yell.md
+++ b/.changeset/lovely-jokes-yell.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/phrasebook': patch
+---
+
+Fixing the error handling bug for `count` argument processing

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -3,6 +3,7 @@ import namespaces from './testing/testNamespaces.json';
 
 describe('processTranslation', () => {
   const locale = 'en-GB';
+  const onError = jest.fn();
 
   describe('Should return expected translated value', () => {
     it.each([
@@ -24,8 +25,10 @@ describe('processTranslation', () => {
           namespaces,
           key,
           args,
+          onError,
         }),
       ).toBe(expected);
+      expect(onError).not.toHaveBeenCalled();
     });
   });
 
@@ -46,16 +49,16 @@ describe('processTranslation', () => {
   });
 
   describe('when calling with wrong param', () => {
-    const onError = jest.fn();
-
     it('Should log the error', () => {
-      expect(processTranslation({
+      const result = processTranslation({
         locale,
         namespaces,
         key: 'stringWithParam',
         args: { ns: 'ns1', param: 'foo' },
         onError,
-      })).toBe('text with parameter: {{wrongParam}}');
+      });
+
+      expect(result).toBe('text with parameter: {{wrongParam}}');
 
       expect(onError).toHaveBeenCalledWith('REPLACE_ARGUMENT_NOT_FOUND', {
         key: 'stringWithParam',

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -19,6 +19,8 @@ const formatArgument = (
   return value;
 };
 
+const COUNT = 'count';
+
 interface ProcessTranslationParams {
   locale: Locale;
   namespaces: Namespaces;
@@ -53,7 +55,7 @@ export const processTranslation = ({
     suffix = args.context;
 
   // @TODO: Update to the new format https://www.i18next.com/translation-function/plurals
-  } else if (typeof args.count !== 'undefined' && args.count !== 1 && args.count !== -1) {
+  } else if (typeof args[COUNT] !== 'undefined' && args[COUNT] !== 1 && args[COUNT] !== -1) {
     suffix = 'plural';
   }
 
@@ -69,12 +71,12 @@ export const processTranslation = ({
     ...replaceableArgs
   } = args;
 
-  // Replace placeholders like `{{count}}` with values from `args`
+  // Replace placeholders like `{{someText}}` with values from `args`
   return Object.entries(replaceableArgs).reduce(
     (v, [ name, value ]) => {
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
 
-      if (onError && !regexp.test(v)) {
+      if (onError && !regexp.test(v) && name !== COUNT) {
         onError(
           'REPLACE_ARGUMENT_NOT_FOUND',
           { key, argumentName: name, value },


### PR DESCRIPTION
Missing count argument should not trigger the error.

<!-- Have you followed the guidelines in our [Contributing](../CONTRIBUTING.md) document? -->

# Description

The `onError` handler introduces in [PR](https://github.com/loveholidays/phrasebook/pull/17) triggered the error for strings with `count` argument. 

Strings could use `count` to:
- use `_plural` suffix
- for argument substitution 

Fixes # (issue)
Omitting missing `count` argument from triggering the error.
