### PR TITLE
Error handling | Checking that arguments not passed

### DIFF
--- a/.changeset/clever-kiwis-care.md
+++ b/.changeset/clever-kiwis-care.md
@@ -1,0 +1,8 @@
+---
+'@loveholidays/phrasebook': minor
+---
+
+- Checking that all the specified parameters in the translation string were passed
+- Stop triggering `onError` when passing the parameter that does not exist in the translation string
+- Changing the error type name `REPLACE_ARGUMENT_NOT_FOUND` -> `REPLACE_ARGUMENT_NOT_PASSED`
+- Removing `value` from the error data payload for `REPLACE_ARGUMENT_NOT_PASSED` error

--- a/.changeset/clever-kiwis-care.md
+++ b/.changeset/clever-kiwis-care.md
@@ -10,7 +10,7 @@ onError handler API:
 
 List if changes:
 
-- Checking that all the specified parameters in the translation string were passed
+- Checking that all the specified parameters in the translation string are passed
 - Stop triggering `onError` when passing the parameter that does not exist in the translation string
 - Changing the error type name `REPLACE_ARGUMENT_NOT_FOUND` -> `REPLACE_ARGUMENT_NOT_PASSED`
 - Removing `value` from the error data payload for `REPLACE_ARGUMENT_NOT_PASSED` error

--- a/.changeset/clever-kiwis-care.md
+++ b/.changeset/clever-kiwis-care.md
@@ -1,6 +1,14 @@
 ---
-'@loveholidays/phrasebook': minor
+'@loveholidays/phrasebook': major
 ---
+
+Breaking change:
+onError handler API:
+
+- removing `REPLACE_ARGUMENT_NOT_FOUND` error
+- adding `REPLACE_ARGUMENT_NOT_PASSED` error
+
+List if changes:
 
 - Checking that all the specified parameters in the translation string were passed
 - Stop triggering `onError` when passing the parameter that does not exist in the translation string

--- a/.changeset/clever-kiwis-care.md
+++ b/.changeset/clever-kiwis-care.md
@@ -8,7 +8,7 @@ onError handler API:
 - removing `REPLACE_ARGUMENT_NOT_FOUND` error
 - adding `REPLACE_ARGUMENT_NOT_PASSED` error
 
-List if changes:
+List of changes:
 
 - Checking that all the specified parameters in the translation string are passed
 - Stop triggering `onError` when passing the parameter that does not exist in the translation string

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const App = () => (
     locale="en-gb"
     translations={translations}
     onError={(errorType, data) => {
-      const { key, argumentName, value } = data;
+      const { key, argumentName } = data;
     }}
   >
     // ...

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_NAMESPACE } from './constants';
 
 import { processTranslation } from './processTranslation';
 import type {
-  Namespaces, Locale, TFunction, TranslationData, TranslationArgumentValue,
+  Namespaces, Locale, TFunction, TranslationData,
 } from './types';
 
 export interface TranslationContextValue {
@@ -21,11 +21,10 @@ export const TranslationContext = createContext<TranslationContextValue>({
 export interface ReplaceArgumentErrorParams {
   key: string;
   argumentName: string;
-  value: TranslationArgumentValue;
 }
 
 export type OnErrorCallback =
-  & ((errorType: 'REPLACE_ARGUMENT_NOT_FOUND', params: ReplaceArgumentErrorParams) => void);
+  & ((errorType: 'REPLACE_ARGUMENT_NOT_PASSED', params: ReplaceArgumentErrorParams) => void);
 
 interface TranslationProviderProps {
   locale: Locale;

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -18,6 +18,8 @@ describe('processTranslation', () => {
       [ 'empty', {}, '' ],
       [ 'title', { ns: 'ns1' }, 'title from namespace 1' ],
       [ 'stringWithParam', { param: 'foo' }, 'text with parameter: foo' ],
+      [ 'stringWithParam', { ns: 'ns1', param1: 'test1', param2: 'test2' }, 'text with parameter: test1' ],
+      [ 'stringWithParam', { ns: 'ns2', param1: 'test1', param2: 'test2' }, 'text with parameters: test1 test2' ],
     ])('%s %p => %s', (key, args, expected) => {
       expect(
         processTranslation({
@@ -54,16 +56,15 @@ describe('processTranslation', () => {
         locale,
         namespaces,
         key: 'stringWithParam',
-        args: { ns: 'ns1', param: 'foo' },
+        args: { param1: 'test' },
         onError,
       });
 
-      expect(result).toBe('text with parameter: {{wrongParam}}');
+      expect(result).toBe('text with parameter: {{ param  }}');
 
-      expect(onError).toHaveBeenCalledWith('REPLACE_ARGUMENT_NOT_FOUND', {
+      expect(onError).toHaveBeenCalledWith('REPLACE_ARGUMENT_NOT_PASSED', {
         key: 'stringWithParam',
         argumentName: 'param',
-        value: 'foo',
       });
     });
   });

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -71,18 +71,25 @@ export const processTranslation = ({
     ...replaceableArgs
   } = args;
 
+  if (onError) {
+    const replaceableParams = translation.match(/{{\s*\w*\s*}}/g);
+
+    replaceableParams?.forEach((p) => {
+      const param = p.replace(/({{\s*|\s*}})/g, '');
+
+      if (replaceableArgs[param] === undefined) {
+        onError(
+          'REPLACE_ARGUMENT_NOT_PASSED',
+          { key, argumentName: param },
+        );
+      }
+    });
+  }
+
   // Replace placeholders like `{{someText}}` with values from `args`
   return Object.entries(replaceableArgs).reduce(
     (v, [ name, value ]) => {
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
-
-      if (onError && !regexp.test(v) && name !== COUNT) {
-        onError(
-          'REPLACE_ARGUMENT_NOT_FOUND',
-          { key, argumentName: name, value },
-        );
-      }
-
       const localizedValue = String(formatArgument(locale, value));
 
       return v.replace(regexp, localizedValue);

--- a/src/testing/testNamespaces.json
+++ b/src/testing/testNamespaces.json
@@ -2,10 +2,11 @@
   "ns1": {
     "title": "title from namespace 1",
     "textWithPlaceholders": "a {{ first }} b <1> c",
-    "stringWithParam": "text with parameter: {{wrongParam}}"
+    "stringWithParam": "text with parameter: {{param1}}"
   },
   "ns2": {
-    "title": "title from namespace 2"
+    "title": "title from namespace 2",
+    "stringWithParam": "text with parameters: {{param1}} {{param2}}"
   },
   "": {
     "search": {
@@ -22,6 +23,6 @@
     "oneParamTwoComponents": "param first {{ first }} component one <1> component 2 <2> something at the end",
     "twoParamsOneComponent": "param first {{ first }} param second {{ second }} component one <1> something at the end",
     "componentWithChildren": "this makes it possible to <1>make some parts</1> of the <2>text</2> appear as links",
-    "stringWithParam": "text with parameter: {{param}}"
+    "stringWithParam": "text with parameter: {{ param  }}"
   }
 }


### PR DESCRIPTION
<!-- Have you followed the guidelines in our [Contributing](../CONTRIBUTING.md) document? -->

# Description

Changing the onError handler behavior
- removing `REPLACE_ARGUMENT_NOT_FOUND` error.
Allowing to pass an argument to the translation string that doesn't have such an argument.

- adding `REPLACE_ARGUMENT_NOT_PASSED` error.
Triggering the error when the translation string contain the argument that was not provided.

Fixes # (issue)

- Checking that all the specified parameters in the translation string were passed
- Stop triggering `onError` when passing the parameter that does not exist in the translation string
- Changing the error type name `REPLACE_ARGUMENT_NOT_FOUND` -> `REPLACE_ARGUMENT_NOT_PASSED`
- Removing `value` from the error data payload for `REPLACE_ARGUMENT_NOT_PASSED` error

Marking this as major since changing the `onError` API is a breaking change
