### PR TITLE
Fix React 18 compatibility in TranslationProvider

### DIFF
--- a/.changeset/thirty-adults-bathe.md
+++ b/.changeset/thirty-adults-bathe.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/phrasebook': patch
+---
+
+Fix React 18 compatibility by using explicit children prop in TranslationProvider

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -70,7 +70,7 @@ export const useTranslation = (namespace?: string) => ({
  * @param {object} props.translations Translation for default locale.
  * @param {function} props.onError Callback could be used to track the error during translation processing.
  * */
-export const TranslationProvider: React.FC<TranslationProviderProps> = ({
+export const TranslationProvider: React.FC<React.PropsWithChildren<TranslationProviderProps>> = ({
   locale,
   namespaces,
   translations,


### PR DESCRIPTION
# Description

In React 18, you need to be explicit with your `children` prop, this PR resolves this, shouldn't introduce any issues with backwards compatibility.

This is the error:
```
Type '{ children: Element[]; locale: string; translations: JsonifyObject<{ [x: string]: string; }>; }' is not assignable to type 'IntrinsicAttributes & TranslationProviderProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & TranslationProviderProps'.ts(2322)
  ```

More info regarding this can be found here: https://solverfox.dev/writing/no-implicit-children/