### PR TITLE
Fix hook use in the t function

### DIFF
--- a/.changeset/curly-fans-work.md
+++ b/.changeset/curly-fans-work.md
@@ -1,0 +1,5 @@
+---
+'@loveholidays/phrasebook': patch
+---
+
+Fix bug using a hook in the t function

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -52,14 +52,18 @@ export interface UseTranslationReturnValue {
   t: TFunction;
 }
 
-export const useTranslation = (namespace?: string) => ({
-  t: namespace
-    ? (key, args) => useContext(TranslationContext).t(key, {
-      ns: namespace,
-      ...args,
-    })
-    : useContext(TranslationContext).t,
-}) as UseTranslationReturnValue;
+export const useTranslation = (namespace?: string) => {
+  const { t } = useContext(TranslationContext);
+
+  return {
+    t: namespace
+      ? (key, args) => t(key, {
+        ns: namespace,
+        ...args,
+      })
+      : t,
+  } as UseTranslationReturnValue;
+};
 
 /**
  * TranslationProvider


### PR DESCRIPTION
<!-- Have you followed the guidelines in our [Contributing](../CONTRIBUTING.md) document? -->

# Description

Move the useContext call up so it isn't called in the returned t function

This is a hook antipattern - other hooks should not be called inside returned functions as this makes them unusable outside of the render loop.

Here is an example of where this was causing a problem:
```tsx
const SomeComponent: React.FC = () => {
  const { t } = useTranslation();

  const handleClick = () => {
    // This will error, as it is trying to use a hook - useContext - outside the render loop
    window.alert(t('alertMessage'));
  }

  return (
    <button 
      onClick={handleClick}
    >
      {t('buttonLabel')}
   </button>
  );
}
```

I'm actually really surprised this hadn't caused issues with conditional uses of `t` messing up the hook call order....