### PR TITLE
feat: Introduce a number locale override

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,29 @@ $ yarn add @loveholidays/phrasebook
 ```
 
 ## Using a dev version of Phrasebook in a dev app
+
 We can use yalc for this, which creates a local store that we can publish and pull dependencies from.
 
 To publish Phrasebook to the local store:
+
 ```bash
 npx --yes yalc publish
 ```
 
 In your target repo (eg. sunrise), update the dependency to local Phrasebook:
+
 ```bash
 npx yalc add @loveholidays/phrasebook
 ```
 
 If you make a change in your local Phrasebook repo, update the local store and the target repo:
+
 ```bash
 npx yalc publish --push
 ```
+
 To reset the dependency of Phraseboook, in your target repo run:
+
 ```bash
 npx yalc remove @loveholidays/phrasebook
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ $ npm i -S @loveholidays/phrasebook
 $ yarn add @loveholidays/phrasebook
 ```
 
+## Using a dev version of Phrasebook in a dev app
+We can use yalc for this, which creates a local store that we can publish and pull dependencies from.
+
+To publish Phrasebook to the local store:
+```bash
+npx --yes yalc publish
+```
+
+In your target repo (eg. sunrise), update the dependency to local Phrasebook:
+```bash
+npx yalc add @loveholidays/phrasebook
+```
+
+If you make a change in your local Phrasebook repo, update the local store and the target repo:
+```bash
+npx yalc publish --push
+```
+To reset the dependency of Phraseboook, in your target repo run:
+```bash
+npx yalc remove @loveholidays/phrasebook
+```
+
 ## Usage
 
 Use the `TranslationProvider` to create the localisation context:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "eslint --ext .ts,.tsx ./src && prettier -c '**/*.json' '**/*.md'",
     "lint:fix": "eslint --ext .ts,.tsx ./src --fix && prettier -w '**/*.json' '**/*.md'",
     "lint:info": "eslint --print-config .eslintrc.js",
-    "changeset": "changeset"
+    "changeset": "changeset",
+    "yalc:publish": "npm run build && npm pack && npx -y yalc publish --push"
   },
   "repository": {
     "type": "git",

--- a/src/TranslationProvider.spec.tsx
+++ b/src/TranslationProvider.spec.tsx
@@ -106,7 +106,7 @@ describe('TranslationProvider', () => {
         />
         <TestComponent
           name="reviews"
-          args={{ count: 12345, numberLocale: 'de-DE' }}
+          args={{ count: 12345, overrideLocale: 'de-DE' }}
         />
       </TranslationProvider>,
     );

--- a/src/TranslationProvider.spec.tsx
+++ b/src/TranslationProvider.spec.tsx
@@ -93,4 +93,20 @@ describe('TranslationProvider', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('should override number format', () => {
+    const { asFragment } = render(
+      <TranslationProvider
+        locale={locale}
+        namespaces={namespaces}
+      >
+        <TestComponent
+          name="reviews"
+          args={{ count: 12345, numberLocale: "de-DE" }}
+        />
+      </TranslationProvider>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  })
 });

--- a/src/TranslationProvider.spec.tsx
+++ b/src/TranslationProvider.spec.tsx
@@ -102,11 +102,11 @@ describe('TranslationProvider', () => {
       >
         <TestComponent
           name="reviews"
-          args={{ count: 12345, numberLocale: "de-DE" }}
+          args={{ count: 12345, numberLocale: 'de-DE' }}
         />
-      </TranslationProvider>
+      </TranslationProvider>,
     );
 
     expect(asFragment()).toMatchSnapshot();
-  })
+  });
 });

--- a/src/TranslationProvider.spec.tsx
+++ b/src/TranslationProvider.spec.tsx
@@ -102,7 +102,7 @@ describe('TranslationProvider', () => {
       >
         <TestComponent
           name="reviews"
-          args={{ count: 12345, }}
+          args={{ count: 12345 }}
         />
         <TestComponent
           name="reviews"

--- a/src/TranslationProvider.spec.tsx
+++ b/src/TranslationProvider.spec.tsx
@@ -102,6 +102,10 @@ describe('TranslationProvider', () => {
       >
         <TestComponent
           name="reviews"
+          args={{ count: 12345, }}
+        />
+        <TestComponent
+          name="reviews"
           args={{ count: 12345, numberLocale: 'de-DE' }}
         />
       </TranslationProvider>,

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -5,6 +5,7 @@ import { processTranslation } from './processTranslation';
 import type {
   Namespaces, Locale, TFunction, TranslationData,
 } from './types';
+import {TranslationArguments} from "./types";
 
 export interface TranslationContextValue {
   locale: Locale;
@@ -92,13 +93,22 @@ export const TranslationProvider: React.FC<React.PropsWithChildren<TranslationPr
       value={{
         locale,
         namespaces: mergedNamespaces,
-        t: (key, args) => processTranslation({
-          locale,
-          namespaces: mergedNamespaces,
-          key,
-          args,
-          onError,
-        }),
+        t: (key: string, args: TranslationArguments | undefined): string => {
+          let numberLocale: Locale = locale;
+          if (args?.numberLocale) {
+            numberLocale = args.numberLocale;
+            delete args.numberLocale;
+          }
+
+          return processTranslation({
+            locale,
+            numberLocale: numberLocale ?? locale,
+            namespaces: mergedNamespaces,
+            key,
+            args,
+            onError,
+          })
+        },
       }}
     >
       {children}

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -94,14 +94,13 @@ export const TranslationProvider: React.FC<React.PropsWithChildren<TranslationPr
         locale,
         namespaces: mergedNamespaces,
         t: (key: string, args: TranslationArguments | undefined): string => {
-          const numberLocale = args?.numberLocale
-            ? args.numberLocale
+          const targetLocale = args?.overrideLocale
+            ? args.overrideLocale
             : locale;
 
           return processTranslation({
             namespaces: mergedNamespaces,
-            locale,
-            numberLocale,
+            locale: targetLocale,
             key,
             args,
             onError,

--- a/src/TranslationProvider.tsx
+++ b/src/TranslationProvider.tsx
@@ -5,7 +5,7 @@ import { processTranslation } from './processTranslation';
 import type {
   Namespaces, Locale, TFunction, TranslationData,
 } from './types';
-import {TranslationArguments} from "./types";
+import { TranslationArguments } from './types';
 
 export interface TranslationContextValue {
   locale: Locale;
@@ -94,20 +94,18 @@ export const TranslationProvider: React.FC<React.PropsWithChildren<TranslationPr
         locale,
         namespaces: mergedNamespaces,
         t: (key: string, args: TranslationArguments | undefined): string => {
-          let numberLocale: Locale = locale;
-          if (args?.numberLocale) {
-            numberLocale = args.numberLocale;
-            delete args.numberLocale;
-          }
+          const numberLocale = args?.numberLocale
+            ? args.numberLocale
+            : locale;
 
           return processTranslation({
-            locale,
-            numberLocale: numberLocale ?? locale,
             namespaces: mergedNamespaces,
+            locale,
+            numberLocale,
             key,
             args,
             onError,
-          })
+          });
         },
       }}
     >

--- a/src/__snapshots__/TranslationProvider.spec.tsx.snap
+++ b/src/__snapshots__/TranslationProvider.spec.tsx.snap
@@ -40,6 +40,9 @@ exports[`TranslationProvider merges namespaces when nesting providers 1`] = `
 exports[`TranslationProvider should override number format 1`] = `
 <DocumentFragment>
   <span>
+    12,345 reviews
+  </span>
+  <span>
     12.345 reviews
   </span>
 </DocumentFragment>

--- a/src/__snapshots__/TranslationProvider.spec.tsx.snap
+++ b/src/__snapshots__/TranslationProvider.spec.tsx.snap
@@ -36,3 +36,11 @@ exports[`TranslationProvider merges namespaces when nesting providers 1`] = `
   </span>
 </DocumentFragment>
 `;
+
+exports[`TranslationProvider should override number format 1`] = `
+<DocumentFragment>
+  <span>
+    12.345 reviews
+  </span>
+</DocumentFragment>
+`;

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -73,10 +73,10 @@ describe('processTranslation', () => {
   });
 
   describe('Override number locale', () => {
-    it("should format number based on override locale", () => {
+    it('should format number based on override locale', () => {
       const result = processTranslation({
         locale,
-        numberLocale: "de-DE",
+        numberLocale: 'de-DE',
         namespaces,
         key: 'reviews',
         args: { count: 12345 },
@@ -84,6 +84,6 @@ describe('processTranslation', () => {
       });
 
       expect(result).toBe('12.345 reviews');
-    })
-  })
+    });
+  });
 });

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -75,8 +75,7 @@ describe('processTranslation', () => {
   describe('Override number locale', () => {
     it('should format number based on override locale', () => {
       const result = processTranslation({
-        locale,
-        numberLocale: 'de-DE',
+        locale: 'de-DE',
         namespaces,
         key: 'reviews',
         args: { count: 12345 },

--- a/src/processTranslation.spec.tsx
+++ b/src/processTranslation.spec.tsx
@@ -71,4 +71,19 @@ describe('processTranslation', () => {
       });
     });
   });
+
+  describe('Override number locale', () => {
+    it("should format number based on override locale", () => {
+      const result = processTranslation({
+        locale,
+        numberLocale: "de-DE",
+        namespaces,
+        key: 'reviews',
+        args: { count: 12345 },
+        onError,
+      });
+
+      expect(result).toBe('12.345 reviews');
+    })
+  })
 });

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -23,7 +23,7 @@ const COUNT = 'count';
 
 interface ProcessTranslationParams {
   locale: Locale;
-  numberLocale?: Locale,
+  numberLocale?: Locale;
   namespaces: Namespaces;
   key: string;
   onError?: OnErrorCallback;

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -23,7 +23,6 @@ const COUNT = 'count';
 
 interface ProcessTranslationParams {
   locale: Locale;
-  numberLocale?: Locale;
   namespaces: Namespaces;
   key: string;
   onError?: OnErrorCallback;
@@ -32,7 +31,6 @@ interface ProcessTranslationParams {
 
 export const processTranslation = ({
   locale,
-  numberLocale = locale,
   namespaces,
   key,
   onError,
@@ -89,7 +87,7 @@ export const processTranslation = ({
   return Object.entries(replaceableArgs).reduce(
     (v, [ name, value ]) => {
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
-      const localizedValue = String(formatArgument(numberLocale, value));
+      const localizedValue = String(formatArgument(locale, value));
 
       return v.replace(regexp, localizedValue);
     },

--- a/src/processTranslation.tsx
+++ b/src/processTranslation.tsx
@@ -23,6 +23,7 @@ const COUNT = 'count';
 
 interface ProcessTranslationParams {
   locale: Locale;
+  numberLocale?: Locale,
   namespaces: Namespaces;
   key: string;
   onError?: OnErrorCallback;
@@ -31,6 +32,7 @@ interface ProcessTranslationParams {
 
 export const processTranslation = ({
   locale,
+  numberLocale = locale,
   namespaces,
   key,
   onError,
@@ -87,7 +89,7 @@ export const processTranslation = ({
   return Object.entries(replaceableArgs).reduce(
     (v, [ name, value ]) => {
       const regexp = new RegExp(`{{\\s*${name}\\s*}}`, 'g');
-      const localizedValue = String(formatArgument(locale, value));
+      const localizedValue = String(formatArgument(numberLocale, value));
 
       return v.replace(regexp, localizedValue);
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type TranslationArgumentValue = string | number | undefined;
 export type TranslationArguments = {
   count?: number;
   context?: string;
-  numberLocale?: Locale;
+  overrideLocale?: Locale;
   [name: string]: TranslationArgumentValue;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type TranslationArgumentValue = string | number | undefined;
 export type TranslationArguments = {
   count?: number;
   context?: string;
+  numberLocale?: Locale;
   [name: string]: TranslationArgumentValue;
 };
 


### PR DESCRIPTION
# Description

We need to be able to format numbers on the AT point of sale like we do in DE

This is handed by `Intl.NumberFormat(locale, value)` in Phrasebook

We pass `de-AT` as the locale on the AT pos, where we expect numbers to be formatted like `12.345` but instead we see `12 345`. This is because `Intl.NumberFormat()` doesn't really recognise `de-AT` and just falls back to a default

To handle this, and render numbers in AT like they are shown in DE, I propose here to pass through the `t()` method an override locale, the reasons for this are 

- Passing a preformatted stringified `count` value will shut of the inbuilt pluralisation functionality, and would require a fair amount of logic to parse these values back to numbers to regain it, considering that DE formatted numbers like decimals to the outside world this is a bit tricky `1.234 -> 1` etc
- We already have a secondary locale in place in sunrise that can be configured via Sanity so passing this value on a need to use basis is rather simple by the consumer

Expected usage in consumers

```typescript
const { t } = useTranslation();
const {
  site: { secondaryLocale },
} = useAppContext();

... 
t('xHolidaysFound', { count, overrideLocale: secondaryLocale })
```

For these reasons the proposed changes in this PR yield the simplest way forward
